### PR TITLE
AMS-3284 Fix textmining errors

### DIFF
--- a/plugin/src/main/content/com.atex.plugins.textmining.common.content
+++ b/plugin/src/main/content/com.atex.plugins.textmining.common.content
@@ -4,4 +4,6 @@ inputtemplate:com.atex.plugins.textmining.textMiningConfigTemplate
 securityparent:p.siteengine.Configuration.d
 name:Textmining Configuration
 
-
+#Dimension Name
+component:dimensionName:value:IPTC
+component:dimensionId:value:dimension.IPTC


### PR DESCRIPTION
- Ensure TextMiningConfigPolicy.getProvider returns a default provider if config hasn't been set.
- Ensure TextMiningConfigPolicy.getProviderName returns default provider name if not set.
- Ensure TextMiningConfigPolicy.getApiKey returns an empty string if no API key it set.